### PR TITLE
Add CodeCoverage (CodeCov.IO) support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,13 @@ install:
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 build_script:
 - ps: ./Build.ps1
-test: off
+test_script:
+  - nuget.exe install OpenCover -ExcludeVersion
+  - OpenCover\tools\OpenCover.Console.exe -register:user -filter:"+[MessageTemplates]*" -target:"dotnet.exe" "-targetargs:test test\MessageTemplates.Tests" -returntargetcode -hideskipped:All -output:coverage.xml
+  - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
+  - pip install codecov
+  - codecov -f "coverage.xml"
+
 artifacts:
 - path: artifacts/MessageTemplates.*.nupkg
 deploy:


### PR DESCRIPTION
CodeCov.IO is a free (for FOSS) Code coverage platform in the cloud. You can sign up with your GitHub account and add in the future badges and webhooks. 

This PR will submit the code coverage to CodeCov.IO 
